### PR TITLE
replaced target_compile_definitions() with set command to work with ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ add_subdirectory(skv)
 foreach(_test ${TEST_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
-  target_compile_definitions(${TEST_NAME} PUBLIC
+  set_target_properties(${TEST_NAME} PROPERTIES COMPILE_DEFINITIONS
     "SKV_CLIENT_UNI;SKV_NON_MPI")
   target_link_libraries(${TEST_NAME} skvc skv_client skv_common it_api fxlogger
     ${MPI_LIBRARIES} ${SKV_COMMON_LINK_LIBRARIES})


### PR DESCRIPTION
...cmake version 2.8.8

The target_compile_definitions was introduced after cmake 2.8.8. I don't think, we should require this just because of one line in CMakeLists.txt.
@eile do you think that's reasonable?
