### PR TITLE
enable CNK build config, cleanup of some linking

### DIFF
--- a/CMake/MPI/MPICH_BGQ.cmake
+++ b/CMake/MPI/MPICH_BGQ.cmake
@@ -1,0 +1,31 @@
+#
+# Manually setup MPI variables for static linking on BGQ
+#  
+set( CNK_BASE             /bgsys/drivers/ppcfloor)
+set( CNK_MPI_INCLUDES     ${CNK_BASE}/comm/lib/gnu  ${CNK_BASE} ${CNK_BASE}/comm/sys/include ${CNK_BASE}/spi/include ${CNK_BASE}/spi/include/kernel/cnk)
+set( CNK_MPI_LIB_ROOT     ${CNK_BASE}/comm/lib )
+set( CNK_MPI_LIBPATH      ${CNK_BASE}/comm/lib ${CNK_BASE} ${CNK_BASE}/comm/lib64 ${CNK_BASE}/spi/lib ${CNK_BASE}/comm/sys/lib)
+
+set( MPI_FOUND 1)
+set( MPI_INCLUDE_PATH     ${CNK_MPI_INCLUDES} CACHE STRING "" FORCE)
+set( MPI_C_INCLUDE_PATH   ${CNK_MPI_INCLUDES} CACHE STRING "" FORCE)
+set( MPI_CXX_INCLUDE_PATH ${CNK_MPI_INCLUDES} CACHE STRING "" FORCE)
+
+#
+# List of libraries collected from mpicxx wrapper
+#
+set( MPI_EXTRA_LIBRARY 
+  ${CNK_MPI_LIB_ROOT}/libmpich-gcc.a;
+  ${CNK_MPI_LIB_ROOT}/libopa-gcc.a;
+  ${CNK_MPI_LIB_ROOT}/libmpl-gcc.a;
+  ${CNK_MPI_LIB_ROOT}/libpami-gcc.a;
+  ${CNK_BASE}/spi/lib/libSPI.a
+  ${CNK_BASE}/spi/lib/libSPI_cnk.a
+  rt;pthread CACHE STRING "" FORCE )
+
+#
+# Newer cmake FindMPI uses per language settings
+#
+set( MPI_C_LIBRARIES       ${MPI_EXTRA_LIBRARY} CACHE STRING "" FORCE )
+set( MPI_CXX_LIBRARIES     ${CNK_MPI_LIB_ROOT}/libmpichcxx-gcc.a ${MPI_EXTRA_LIBRARY} CACHE STRING "" FORCE )
+set( MPI_LIBRARY           ${MPI_EXTRA_LIBRARY} CACHE STRING "" FORCE )

--- a/CMake/Site/bgq_cnk.cmake
+++ b/CMake/Site/bgq_cnk.cmake
@@ -1,0 +1,6 @@
+set(MPI_CXX_COMPILER /bgsys/drivers/ppcfloor/comm/gcc/bin/mpicxx)
+set(MPI_C_COMPILER /bgsys/drivers/ppcfloor/comm/gcc/bin/mpicc)
+
+set(SKV_ENV "BGQCNK" )
+set(SKV_MPI "MPICH_BGQ" )
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,14 @@ set_property(CACHE SKV_COMM_API_TYPE
 
 if(SKV_COMM_API_TYPE MATCHES "verbs")
   find_package(OFED REQUIRED)
+  set( IT_API_LIBS ${OFED_LIBRARIES} pthread rt )
   add_definitions(
     # enable workaround for missing RoQ loopback functionality
     -DSKV_ROQ_LOOPBACK_WORKAROUND
   )
+endif()
+if(SKV_COMM_API_TYPE MATCHES "sockets")
+  set( IT_API_LIBS pthread rt )
 endif()
 
 
@@ -145,7 +149,7 @@ set(IT_API_PUBLIC_HEADERS
   it_api/it_api_os_specific.h
 )
 
-set(IT_API_LINK_LIBRARIES ${OFED_LIBRARIES})
+set(IT_API_LINK_LIBRARIES ${IT_API_LIBS} )
 
 
 
@@ -218,15 +222,15 @@ foreach(_test ${TEST_SOURCES})
   set_target_properties(${TEST_NAME} PROPERTIES COMPILE_DEFINITIONS
     "SKV_CLIENT_UNI;SKV_NON_MPI")
   target_link_libraries(${TEST_NAME} skvc skv_client skv_common it_api fxlogger
-    ${MPI_LIBRARIES} ${SKV_COMMON_LINK_LIBRARIES})
+    ${SKV_COMMON_LINK_LIBRARIES})
   install(TARGETS ${TEST_NAME} DESTINATION bin)
 endforeach()
 
 foreach(_test ${TEST_MPI_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
-  target_link_libraries(${TEST_NAME} skvc_mpi skv_client_mpi skv_common it_api fxlogger
-    ${MPI_LIBRARIES} ${SKV_COMMON_LINK_LIBRARIES})
+  target_link_libraries(${TEST_NAME} skvc_mpi skv_client_mpi skv_common ${IT_API_LINK_LIBRARIES} fxlogger
+    ${MPI_CXX_LIBRARIES} ${SKV_COMMON_LINK_LIBRARIES})
   install(TARGETS ${TEST_NAME} DESTINATION bin)
 endforeach()
 

--- a/skv/CMakeLists.txt
+++ b/skv/CMakeLists.txt
@@ -68,7 +68,7 @@ set(SKVSERVER_SOURCES
   server/skv_server_uber_pds.cpp
 )
 set(SKVSERVER_LINK_LIBRARIES pthread m dl ${OFED_LIBRARIES}
-  ${MPI_LIBRARIES}  ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${ROCKSDB_LIBRARIES}
+  ${MPI_CXX_LIBRARIES}  ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${ROCKSDB_LIBRARIES}
   skv_common it_api fxlogger)
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
enabled CNK build for BG/Q. just set SKV_SITE=bgq_cnk when configuring cmake after setting CC and CXX to the bgq gcc-compilers
