### PR TITLE
Fix build without rocksdb

### DIFF
--- a/skv/CMakeLists.txt
+++ b/skv/CMakeLists.txt
@@ -69,9 +69,15 @@ set(SKVSERVER_SOURCES
   server/skv_server_tree_based_container.cpp
   server/skv_server_uber_pds.cpp
 )
-set(SKVSERVER_LINK_LIBRARIES pthread m dl ${OFED_LIBRARIES}
-  ${MPI_CXX_LIBRARIES}  ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES} ${ROCKSDB_LIBRARIES}
-  skv_common it_api fxlogger)
+
+if(LOCAL_KV_BACKEND MATCHES "rocksdb")
+  set(SKVSERVER_LINK_LIBRARIES pthread m dl ${OFED_LIBRARIES}
+    ${MPI_CXX_LIBRARIES}  ${ZLIB_LIBRARIES} ${BZIP2_LIBRARIES}
+    ${ROCKSDB_LIBRARIES} skv_common it_api fxlogger)
+else()
+  set(SKVSERVER_LINK_LIBRARIES pthread m dl ${OFED_LIBRARIES}
+    ${MPI_CXX_LIBRARIES} skv_common it_api fxlogger)
+endif()
 
 #------------------------------------------------------------------------------
 # libraries


### PR DESCRIPTION
CMake complained about undefined BZIP2_LIBRARIES and ROCKSDB_LIBRARIES when building SKV with backends other than rocksdb.

This is just a quick workaround, not sure if this is the most CMake-friendly way of fixing the issue.