### PR TITLE
fix event signalling between it_api threads and some minor updates

### DIFF
--- a/CMake/logtrace.cmake
+++ b/CMake/logtrace.cmake
@@ -100,7 +100,7 @@ add_definitions(
 # -DSKV_BULK_LOAD_CHECKSUM
 # -DSKV_RETRIEVE_DATA_LOG
 # -DSKV_CTRLMSG_DATA_LOG=1
- -DSKV_COALESCING_STATISTICS
+# -DSKV_COALESCING_STATISTICS
 
 ##################################
 # logging in tests


### PR DESCRIPTION
the last major update broke the direct socket function in favour of the CNK forwarder. Turned out there was a quiet bug in it_api sockets implementation that got unveiled by the larger update.