### PR TITLE
prevent a closing EP to get polled for new commands

### DIFF
--- a/skv/server/skv_server_network_event_manager.cpp
+++ b/skv/server/skv_server_network_event_manager.cpp
@@ -324,6 +324,8 @@ FinalizeEPState(  EPStateMap_T*         aEPStateMap,
     << " aEP: " << (void *) aEP
     << EndLogLine;
 
+  aStateForEP->Closing();
+
   skv_server_finalizable_associated_ep_state_list_t::iterator iter = aStateForEP->mAssociatedStateList->begin();
   skv_server_finalizable_associated_ep_state_list_t::iterator end  = aStateForEP->mAssociatedStateList->end();
 
@@ -349,7 +351,7 @@ FinalizeEPState(  EPStateMap_T*         aEPStateMap,
     }
   }
 
-  aEPStateMap->erase( aEP );
+  aEPStateMap->erase( aEPStateMap->find( aEP ) );
 
   aStateForEP->Finalize();
 

--- a/skv/server/skv_server_types.hpp
+++ b/skv/server/skv_server_types.hpp
@@ -818,10 +818,14 @@ struct skv_server_ep_state_t
     return;
   }
 
+  void Closing()
+  {
+    mEPState_status = SKV_SERVER_ENDPOINT_STATUS_CLOSING;
+  }
+
   void
   Finalize()
   {
-    mEPState_status = SKV_SERVER_ENDPOINT_STATUS_CLOSING;
     mResourceLock.lock();
     BegLogLine( SKV_SERVER_CLEANUP_LOG )
       << "Finalizing EP: " << (void*)this
@@ -1878,7 +1882,7 @@ struct skv_cmd_retrieve_resp_t
   }
 };
 
-// the list of contexts (CCBs)
+// the list of Endpoints and ep handles for reverse lookup
 typedef std::map< it_ep_handle_t, skv_server_ep_state_t* > EPStateMap_T;
 
 class skv_server_internal_event_manager_if_t


### PR DESCRIPTION
This should at least alleviate a problem during connection tear-down, where the command polling thread tries to keep fetching new events from a closing endpoint.