### PR TITLE
config and doc updates

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@
   2. compile
   3. install
   4. runtime env
-
+  5. troubleshooting
 
 ================
 
@@ -179,3 +179,15 @@ will create an RPM that can be used to install SKV.
      later. For now, unfortunately we can only point to the source
      code examples and the file include/client/skv_client.hpp (for C++
      clients) or lib/include/skv.h (for C clients).
+
+     
+     
+================
+5. TROUBLESHOOTING
+
+  * Large Scale runs fail because of open file limit exceeded
+
+    * when running SKV at a large scale - i.e. with many many clients,
+      it is important to observe the user's limit for open file
+      descriptors.  The server needs at least one file desciptor per
+      client (unless clients connect via the forwarder option).

--- a/README
+++ b/README
@@ -142,7 +142,7 @@ will create an RPM that can be used to install SKV.
      cause problems for clients on BG/Q, because they need to connect
      to the loopback address via siw)
 
-   * beef.slab.N: is the mmapped file that contains the stored
+   * skv_store.N: is the mmapped file that contains the stored
      data. Where N is the MPI rank of the server process. Currently,
      all storage memory has to be pinned and thus the capacity per
      node is limited by the amount of available memory and the memlock

--- a/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
+++ b/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
@@ -1888,10 +1888,10 @@ int ConnectToServers( int aMyRank )
   // get configuration to find servers
   skv_configuration_t *config = skv_configuration_t::GetSKVConfiguration();
 
-  ifstream fin( config->GetServerLocalInfoFile() );
+  ifstream fin( config->GetMachineFile() );
 
   StrongAssertLogLine( !fin.fail() )
-    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetServerLocalInfoFile()
+    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetMachineFile()
     << EndLogLine;
 
   // open sockets and connect to servers

--- a/skv/client/skv_client_conn_manager_if.cpp
+++ b/skv/client/skv_client_conn_manager_if.cpp
@@ -360,13 +360,13 @@ Connect( const char* aConfigFile,
   // first pass of the server machine file to get the server count
   BegLogLine( SKV_CLIENT_CONN_INFO_LOG )
     << "skv_client_conn_manager_if_t::Connect():: "
-    << " ComputeFileNamePath: " << config->GetServerLocalInfoFile()
+    << " ComputeFileNamePath: " << config->GetMachineFile()
     << EndLogLine;
 
-  ifstream fin( config->GetServerLocalInfoFile() );
+  ifstream fin( config->GetMachineFile() );
 
   StrongAssertLogLine( !fin.fail() )
-    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetServerLocalInfoFile()
+    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetMachineFile()
     << EndLogLine;
 
 
@@ -401,7 +401,7 @@ Connect( const char* aConfigFile,
 
 
   // Open and parse compute file name
-  ifstream fin1( config->GetServerLocalInfoFile() );
+  ifstream fin1( config->GetMachineFile() );
 
   // get hostname to replace local server names with localhost
   char this_host_name[ SKV_MAX_SERVER_ADDR_NAME_LENGTH ];

--- a/skv/common/skv_array_queue.hpp
+++ b/skv/common/skv_array_queue.hpp
@@ -21,7 +21,7 @@
 template<class T, size_t SKV_ARRAY_QUEUE_SIZE>
 class skv_array_queue_t
 {
-  size_t len;
+  volatile size_t len;
   volatile T *Memory;
   volatile size_t head;
   volatile size_t tail;

--- a/skv/common/skv_config.cpp
+++ b/skv/common/skv_config.cpp
@@ -50,8 +50,6 @@ skv_configuration_t::skv_configuration_t( )
 
   mPersistentFilename      = DEFAULT_SKV_PERSISTENT_FILENAME;
   mPersistentFileLocalPath = DEFAULT_SKV_PERSISTENT_FILE_LOCAL_PATH;
-
-  mLocalInfoFile = DEFAULT_SKV_LOCAL_SERVER_INFO_FILE;
 }
 
 // get the location and name of the config file
@@ -192,10 +190,6 @@ skv_configuration_t::ReadConfigurationFile( const char *aConfigFile )
             mPersistentFileLocalPath = cline.substr( valueIndex );
             break;
 
-          case SKV_CONFIG_SETTING_LOCAL_SERVER_INFO_FILE:
-            mLocalInfoFile = cline.substr( valueIndex );
-            break;
-
           case SKV_CONFIG_SETTING_COMM_IF:
             mCommIF = cline.substr( valueIndex );
             break;
@@ -237,7 +231,6 @@ skv_configuration_t::ReadConfigurationFile( const char *aConfigFile )
     << " ServerPort:" << mServerPort
     << " persFile: " << mPersistentFilename.c_str()
     << " persLocalFile: " << mPersistentFileLocalPath.c_str()
-    << " LocalInfoFile: " << mLocalInfoFile.c_str()
     << " verbsDev" << mCommIF.c_str()
     << EndLogLine;
 
@@ -265,9 +258,6 @@ skv_configuration_t::GetVariableCase( const string s, size_t *valueIndex )
 
     if( s.find( "MACHINE_FILE" ) != string::npos )
       setting = SKV_CONFIG_SETTING_MACHINE_FILE;
-
-    if( s.find( "LOCAL_INFO" ) != string::npos )
-      setting = SKV_CONFIG_SETTING_LOCAL_SERVER_INFO_FILE;
 
     if( s.find( "COMM_IF") != string::npos )
       setting = SKV_CONFIG_SETTING_COMM_IF;
@@ -350,12 +340,6 @@ const char*
 skv_configuration_t::GetServerPersistentFileLocalPath() const
 {
   return mPersistentFileLocalPath.c_str();
-}
-
-const char*
-skv_configuration_t::GetServerLocalInfoFile() const
-{
-  return mLocalInfoFile.c_str();
 }
 
 const char*

--- a/skv/common/skv_config.hpp
+++ b/skv/common/skv_config.hpp
@@ -25,10 +25,9 @@ using namespace std;            // that's a bad place for using... ;-)...
 
 #define DEFAULT_SKV_SERVER_PORT 17002
 #define DEFAULT_SKV_SERVER_READY_FILE "/tmp/skv_server.ready"
-#define DEFAULT_SKV_MACHINE_FILE "/etc/machinefile"
-#define DEFAULT_SKV_PERSISTENT_FILENAME "beef_slab"
-#define DEFAULT_SKV_PERSISTENT_FILE_LOCAL_PATH "/tmp/beef_slab"
-#define DEFAULT_SKV_LOCAL_SERVER_INFO_FILE "/tmp/skv_server_info"
+#define DEFAULT_SKV_MACHINE_FILE "/etc/skv_machinefile"
+#define DEFAULT_SKV_PERSISTENT_FILENAME "skv_store"
+#define DEFAULT_SKV_PERSISTENT_FILE_LOCAL_PATH "/tmp/skv_store"
 #define DEFAULT_SKV_COMM_IF "roq0"
 
 typedef enum {
@@ -38,7 +37,6 @@ typedef enum {
   SKV_CONFIG_SETTING_MACHINE_FILE,
   SKV_CONFIG_SETTING_PERSISTENT_FILENAME,
   SKV_CONFIG_SETTING_PERSISTENT_FILE_LOCAL_PATH,
-  SKV_CONFIG_SETTING_LOCAL_SERVER_INFO_FILE,
   SKV_CONFIG_SETTING_COMM_IF,
 } skv_config_setting_t;
 
@@ -53,7 +51,6 @@ class skv_configuration_t
   string    mMachineFile;
   string    mPersistentFilename;
   string    mPersistentFileLocalPath;
-  string    mLocalInfoFile;
   string    mCommIF;
 
   string    mConfigFile;
@@ -77,7 +74,6 @@ public:
   // input in network byte order
   void SetSKVServerPort( uint32_t aServerPort );
 
-  const char* GetServerLocalInfoFile() const;
   const char* GetCommIF() const;
 
   const string GetConfigFileName() const;

--- a/skv/server/skv_server.cpp
+++ b/skv/server/skv_server.cpp
@@ -1518,7 +1518,7 @@ Init( int   aRank,
 
   sprintf( ServerAddrInfoFilename,
            "%s",
-           mSKVConfiguration->GetServerLocalInfoFile()
+           mSKVConfiguration->GetMachineFile()
            );
 
   BegLogLine( 1 )

--- a/skv/server/skv_server_heap_manager.hpp
+++ b/skv/server/skv_server_heap_manager.hpp
@@ -38,16 +38,11 @@
 #endif
 
 #define PERSISTENT_FILEPATH_MAX_SIZE            512
-// #define PERSISTENT_FILENAME                     "beef_slab"
-//#define PERSISTENT_FILE_LOCAL_PATH              "/tmp/beef_slab"
 #define PERSISTENT_MAGIC_NUMBER                 0xfaceb0b1
 #define IONODE_IP                               "10.255.255.254"
 #define MY_HOSTNAME_SIZE 128
 
-//#define PERSISTENT_IMAGE_MAX_LEN                ( 2u * 1024u * 1024u * 1024u )
 #define PERSISTENT_IMAGE_MAX_LEN                ( 2ull * 1024ull * 1024ull * 1024ull )
-//#define PERSISTENT_IMAGE_MAX_LEN                ( 1024u * 1024u * 1024u )
-//#define PERSISTENT_IMAGE_MAX_LEN                ( 1724u * 1024u * 1024u )
 
 static
 int

--- a/skv/server/skv_server_tree_based_container.cpp
+++ b/skv/server/skv_server_tree_based_container.cpp
@@ -236,7 +236,7 @@ Close( skv_pds_attr_t      *aPDSAttr )
 }
 
 
-int
+size_t
 skv_tree_based_container_t::
 GetMaxDataLoad()
 {

--- a/skv/server/skv_server_tree_based_container.hpp
+++ b/skv/server/skv_server_tree_based_container.hpp
@@ -31,7 +31,7 @@ class skv_tree_based_container_t
 {
   skv_data_container_t*                         mDataMap;
   // In bytes
-  int                                           mMaxDataLoad;
+  size_t                                        mMaxDataLoad;
 
   // Memory for local data
   char*                                         mStartOfDataField;
@@ -98,7 +98,7 @@ public:
   skv_status_t
   Close( skv_pds_attr_t *aPDSAttr );
 
-  int GetMaxDataLoad();
+  size_t GetMaxDataLoad();
 
   skv_status_t Init( it_pz_handle_t aPZ_Hdl,
                      skv_server_internal_event_manager_if_t* aInternalEventManager,

--- a/skv/server/skv_server_types.hpp
+++ b/skv/server/skv_server_types.hpp
@@ -831,6 +831,13 @@ struct skv_server_ep_state_t
       << "Finalizing EP: " << (void*)this
       << EndLogLine;
 
+    while( mInProgressCommands > 1 )
+    {
+      mResourceLock.unlock();
+      usleep( 10000 );
+      mResourceLock.lock();
+    }
+
     delete mAssociatedStateList;
 
     it_lmr_free(mCommandBuffLMR);

--- a/skv/server/skv_server_uber_pds.cpp
+++ b/skv/server/skv_server_uber_pds.cpp
@@ -19,7 +19,7 @@
 #define SKV_SERVER_UBER_PDS_LOG ( 0 | SKV_LOGGING_ALL  )
 #endif
 
-int
+size_t
 skv_uber_pds_t::
 GetMaxDataLoad()
 {

--- a/skv/server/skv_server_uber_pds.hpp
+++ b/skv/server/skv_server_uber_pds.hpp
@@ -95,7 +95,7 @@ public:
 
 
   //
-  int GetMaxDataLoad();
+  size_t GetMaxDataLoad();
 
   skv_status_t Remove( skv_pds_id_t             aPDSId,
                        char*                     aKeyData,

--- a/skv/system/bgq/etc/skv_server.conf
+++ b/skv/system/bgq/etc/skv_server.conf
@@ -30,6 +30,8 @@
 
 # specify which port the server will listen on
 # default: SKV_SERVER_PORT = 17002
+# note that this is only the base port, if a port is blocked SKV will try to
+#  listen on the 10 subsequent ports.  The actual port will be written to the machine file
 SKV_SERVER_PORT = 17002
 
 # the existence of the skv_server ready file signals that the server is running
@@ -51,17 +53,10 @@ SKV_SERVER_MACHINE_FILE = /tmp/skv_machinefile
 # this option specifies the name of the file to avoid filename collisions
 # and allow multiple servers running on the same machine
 #
-# default:  PERSISTENT_FILENAME = "beef_slab"
-PERSISTENT_FILENAME = beef_slab
-PERSISTENT_FILE_LOCAL_PATH = /tmp/beef_slab
+# default:  PERSISTENT_FILENAME = "skv_store"
+PERSISTENT_FILENAME = skv_store
+PERSISTENT_FILE_LOCAL_PATH = /tmp/skv_store
 
-
-
-# If SKV runs multiple instances on a single host, it writes the server infos
-# into the file indicated by this parameter
-# 
-# default: SKV_SERVER_LOCAL_INFO_FILE = "/tmp/skv_server_info"
-SKV_SERVER_LOCAL_INFO_FILE = /tmp/skv_machinefile
 
 # Communication interface that's to be used primarily by the server
 # the corresponding IP address will be placed into the machine file

--- a/test/test_skv_utils.hpp
+++ b/test/test_skv_utils.hpp
@@ -241,7 +241,7 @@ SKVTestGetServerCount()
 
   sprintf( ServerAddrInfoFilename,
            "%s",
-           config->GetServerLocalInfoFile()
+           config->GetMachineFile()
            );
 
   strcpy( ComputeFileNamePath, ServerAddrInfoFilename );      

--- a/unittest/test_skv_cnk_router_connector.cpp
+++ b/unittest/test_skv_cnk_router_connector.cpp
@@ -226,10 +226,10 @@ int main( int argc, char **argv )
   // get configuration to find servers
   skv_configuration_t *config = skv_configuration_t::GetSKVConfiguration();
 
-  ifstream fin( config->GetServerLocalInfoFile() );
+  ifstream fin( config->GetMachineFile() );
 
   StrongAssertLogLine( !fin.fail() )
-    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetServerLocalInfoFile()
+    << "skv_client_conn_manager_if_t::Connect():: ERROR opening server machine file: " << config->GetMachineFile()
     << EndLogLine;
 
   // open sockets and connect to servers


### PR DESCRIPTION
* removed the ambiguous machine file entries in the skv_server.conf file. Now, only one setting is required and you might want to update your skv_server.conf files from the example file shipped in skv/system/bgq/etc/
* the default storage file name base changed to "skv_store"
* minor others