### PR TITLE
fix record locking

### DIFF
--- a/skv/server/skv_local_kv_asyncmem.cpp
+++ b/skv/server/skv_local_kv_asyncmem.cpp
@@ -342,6 +342,10 @@ AllocateAndMoveKey( skv_cmd_RIU_req_t *aReq,
     return status;
   }
 
+  aPDSManager->InBoundsCheck( "AllocateMove",
+                              (char *) aNewRecordAllocRep->GetAddr(),
+                              aNewRecordAllocRep->GetLen() );
+
   // Move the key
   memcpy( (char *)aNewRecordAllocRep->GetAddr(),
           aReq->mKeyValue.mData,
@@ -400,7 +404,7 @@ InsertLocal( skv_cmd_RIU_req_t *aReq,
                                      aMyRank,
                                      gSKVServerInsertInTreeFinis );
 
-  AssertLogLine( status == SKV_SUCCESS )
+  BegLogLine( (SKV_LOCAL_KV_BACKEND_LOG && (status != SKV_SUCCESS )) )
     << "skv_local_kv_asyncmem::InsertLocal():: ERROR: "
     << " status: " << skv_status_to_string( status )
     << EndLogLine;
@@ -707,10 +711,6 @@ skv_local_kv_asyncmem::PerformInsert( skv_local_kv_request_t *aKVReq )
                                 &mPDSManager,
                                 mMyRank );
 
-          AssertLogLine( status == SKV_SUCCESS )
-            << "skv_local_kv_asyncmem::Insert():: ERROR: "
-            << " status: " << skv_status_to_string( status )
-            << EndLogLine;
           /*******************************************************************/
         }
         else
@@ -783,7 +783,6 @@ skv_local_kv_asyncmem::PerformInsert( skv_local_kv_request_t *aKVReq )
                             TotalValueSize,
                             &mPDSManager,
                             mMyRank );
-
     }
   }
   /***********************************************************************/
@@ -1263,24 +1262,6 @@ skv_local_kv_asyncmem::CreateCursor( char* aBuff,
 {
   return mPDSManager.CreateCursor( aBuff, aBuffSize, aServCursorHdl );
 }
-
-skv_status_t
-skv_local_kv_asyncmem::Lock( skv_pds_id_t *aPDSId,
-                          skv_key_value_in_ctrl_msg_t *aKeyValue,
-                          skv_rec_lock_handle_t *aRecLock )
-{
-  return mPDSManager.LockRecord( *aPDSId,
-                                 aKeyValue->mData,
-                                 aKeyValue->mKeySize,
-                                 &(*aRecLock) );
-}
-
-skv_status_t
-skv_local_kv_asyncmem::Unlock( skv_rec_lock_handle_t aLock )
-{
-  return mPDSManager.UnlockRecord( aLock );
-}
-
 
 skv_status_t
 skv_local_kv_asyncmem::RDMABoundsCheck( const char* aContext,

--- a/skv/server/skv_local_kv_asyncmem.hpp
+++ b/skv/server/skv_local_kv_asyncmem.hpp
@@ -255,12 +255,6 @@ public:
                        int aKeySize,
                        skv_local_kv_cookie_t *aCookie );
 
-  skv_status_t Lock( skv_pds_id_t *aPDSId,
-                     skv_key_value_in_ctrl_msg_t *aKeyValue,
-                     skv_rec_lock_handle_t *aRecLock );
-
-  skv_status_t Unlock( skv_rec_lock_handle_t aLock );
-
   skv_status_t RDMABoundsCheck( const char* aContext,
                                 char* aMem,
                                 int aSize );

--- a/skv/server/skv_local_kv_inmem.cpp
+++ b/skv/server/skv_local_kv_inmem.cpp
@@ -201,7 +201,7 @@ InsertLocal( skv_cmd_RIU_req_t *aReq,
                                      aMyRank,
                                      gSKVServerInsertInTreeFinis );
 
-  AssertLogLine( status == SKV_SUCCESS )
+  BegLogLine( (SKV_LOCAL_KV_BACKEND_LOG && (status != SKV_SUCCESS )) )
     << "skv_local_kv_inmem::InsertLocal():: ERROR: "
     << " status: " << skv_status_to_string( status )
     << EndLogLine;
@@ -862,24 +862,6 @@ skv_local_kv_inmem::CreateCursor( char* aBuff,
 {
   return mPDSManager.CreateCursor( aBuff, aBuffSize, aServCursorHdl );
 }
-
-skv_status_t
-skv_local_kv_inmem::Lock( skv_pds_id_t *aPDSId,
-                          skv_key_value_in_ctrl_msg_t *aKeyValue,
-                          skv_rec_lock_handle_t *aRecLock )
-{
-  return mPDSManager.LockRecord( *aPDSId,
-                                 aKeyValue->mData,
-                                 aKeyValue->mKeySize,
-                                 &(*aRecLock) );
-}
-
-skv_status_t
-skv_local_kv_inmem::Unlock( skv_rec_lock_handle_t aLock )
-{
-  return mPDSManager.UnlockRecord( aLock );
-}
-
 
 skv_status_t
 skv_local_kv_inmem::RDMABoundsCheck( const char* aContext,

--- a/skv/server/skv_local_kv_inmem.hpp
+++ b/skv/server/skv_local_kv_inmem.hpp
@@ -107,12 +107,6 @@ public:
                        int aKeySize,
                        skv_local_kv_cookie_t *aCookie );
 
-  skv_status_t Lock( skv_pds_id_t *aPDSId,
-                     skv_key_value_in_ctrl_msg_t *aKeyValue,
-                     skv_rec_lock_handle_t *aRecLock );
-
-  skv_status_t Unlock( skv_rec_lock_handle_t aLock );
-
   skv_status_t RDMABoundsCheck( const char* aContext,
                                 char* aMem,
                                 int aSize );

--- a/skv/server/skv_local_kv_interface.hpp
+++ b/skv/server/skv_local_kv_interface.hpp
@@ -369,6 +369,10 @@ public:
    *************************************************************/
 
   /*
+   * LockManager functions (not to be implemented by the LKVS
+   */
+
+  /*
    * Lock attempts to create a lock based on PDS+Key and assigns it to an owner
    * if the record is not locked or if the owner retries to lock, the function returns SKV_SUCCESS
    * if a non-owner tries to lock a record that already locked, SKV_ERRNO_RECORD_IS_LOCKED is returned

--- a/skv/server/skv_local_kv_rocksdb.cpp
+++ b/skv/server/skv_local_kv_rocksdb.cpp
@@ -1323,24 +1323,11 @@ skv_status_t skv_local_kv_rocksdb_worker_t::PerformRemove( skv_local_kv_request_
 }
 
 skv_status_t
-skv_local_kv_rocksdb::Lock( skv_pds_id_t *aPDSId,
-                            skv_key_value_in_ctrl_msg_t *aKeyValue,
-                            skv_rec_lock_handle_t *aRecLock )
-{
-  return SKV_ERRNO_NOT_IMPLEMENTED;
-}
-skv_status_t
-skv_local_kv_rocksdb::Unlock( skv_rec_lock_handle_t aLock )
-{
-  return SKV_ERRNO_NOT_IMPLEMENTED;
-}
-
-skv_status_t
 skv_local_kv_rocksdb::RDMABoundsCheck( const char* aContext,
                                        char* aMem,
                                        int aSize )
 {
-  return SKV_ERRNO_NOT_IMPLEMENTED;
+  return SKV_SUCCESS;
 }
 
 skv_status_t

--- a/skv/server/skv_local_kv_rocksdb.hpp
+++ b/skv/server/skv_local_kv_rocksdb.hpp
@@ -385,11 +385,6 @@ public:
                        int aKeySize,
                        skv_local_kv_cookie_t *aCookie );
 
-  skv_status_t Lock( skv_pds_id_t *aPDSId,
-                     skv_key_value_in_ctrl_msg_t *aKeyValue,
-                     skv_rec_lock_handle_t *aRecLock );
-  skv_status_t Unlock( skv_rec_lock_handle_t aLock );
-
 
   skv_status_t RDMABoundsCheck( const char* aContext,
                                 char* aMem,

--- a/skv/server/skv_server_lock_manager.hpp
+++ b/skv/server/skv_server_lock_manager.hpp
@@ -1,0 +1,229 @@
+/************************************************
+ * Copyright (c) IBM Corp. 2014-2015
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *************************************************/
+
+/*
+ * skv_server_lock_manager.hpp
+ *
+ *  Created on: May 5, 2015
+ *      Author: lschneid
+ */
+
+#ifndef SKV_SERVER_SKV_SERVER_LOCK_MANAGER_HPP_
+#define SKV_SERVER_SKV_SERVER_LOCK_MANAGER_HPP_
+
+#ifndef SKV_SERVER_RECORD_LOCK_MGR_LOG
+#define SKV_SERVER_RECORD_LOCK_MGR_LOG ( 0 | SKV_LOGGING_ALL )
+#endif
+
+#include <set>
+
+class skv_server_record_lock_key_t
+{
+  skv_pds_id_t mPDSId;
+  skv_key_t mKey;
+
+public:
+  skv_server_record_lock_key_t()
+  {
+    mPDSId.Init( 0, 0 );
+    mKey.Init( NULL, 0 );
+    mKey.mData = new char[ SKV_CONTROL_MESSAGE_SIZE ];
+  }
+  skv_server_record_lock_key_t( const skv_pds_id_t &aPDSId,
+                                const skv_key_t &aKey )
+  {
+    setPdsId( aPDSId );
+    mKey.mData = new char[ SKV_CONTROL_MESSAGE_SIZE ];
+    setKey( aKey );
+  }
+  ~skv_server_record_lock_key_t()
+  {
+  // deleting mKey.mData caused double-delete error
+  }
+
+  const skv_key_t& getKey() const
+  {
+    return mKey;
+  }
+
+  void setKey( const skv_key_value_in_ctrl_msg_t &aKeyVal )
+  {
+    mKey.mSizeBE = aKeyVal.mKeySize;
+    if( mKey.mSizeBE < SKV_CONTROL_MESSAGE_SIZE )
+      memcpy( mKey.mData, aKeyVal.mData, mKey.mSizeBE );
+    else
+      StrongAssertLogLine( 0 )
+        << "KeySize too large (check client request or potential endian issue)."
+        << " size=" << mKey.mSizeBE
+        << " in hex=0x" << (void*)mKey.mSizeBE
+        << EndLogLine;
+  }
+  void setKey( const skv_key_t& aKey )
+  {
+    mKey = aKey;
+  }
+
+  skv_pds_id_t getPdsId() const
+  {
+    return mPDSId;
+  }
+
+  void setPdsId( const skv_pds_id_t &aPDSId )
+  {
+    mPDSId.Init( aPDSId.mOwnerNodeId, aPDSId.mIdOnOwner );
+  }
+
+  bool
+  operator==( const skv_server_record_lock_key_t &aLockRec ) const
+  {
+    if( (aLockRec.mPDSId == mPDSId) )
+      return (mKey == aLockRec.mKey);
+    else
+      return 0;
+  }
+
+  bool
+  operator<( const skv_server_record_lock_key_t &aLockRec ) const
+  {
+    if( mPDSId < aLockRec.mPDSId )
+    {
+      return 1;
+    }
+    else if( mPDSId == aLockRec.mPDSId )
+    {
+      int rc = (mKey < aLockRec.mKey);
+
+      return rc;
+    }
+    else
+    {
+      return 0;
+    }
+  }
+
+};
+
+
+struct skv_server_record_lock_t
+{
+  skv_server_record_lock_key_t mKey;
+  skv_server_ccb_t *mLockOwner;
+};
+
+// once there's a decision to accept C++11 features by default, this could be changed to an unordered map
+typedef std::map< skv_server_record_lock_key_t,
+                  skv_server_ccb_t*,
+                  less< skv_server_record_lock_key_t >,
+                  skv_allocator_t< std::pair< skv_server_record_lock_key_t, skv_server_record_lock_t* >> > skv_server_record_lock_vault_t;;
+
+class skv_server_lock_manager_t
+{
+  skv_server_record_lock_vault_t mActiveLocks;
+  skv_server_record_lock_t mTmpRecord;
+  skv_mutex_t mSerializer;
+
+public:
+  skv_server_lock_manager_t()
+  {
+  }
+  ~skv_server_lock_manager_t()
+  {
+  }
+
+  skv_status_t Lock( const skv_pds_id_t *aPDSId,
+                     const skv_key_value_in_ctrl_msg_t *aKeyValue,
+                     const skv_server_ccb_t *aOwner,
+                     skv_rec_lock_handle_t *aRecLock )
+  {
+    skv_status_t status = SKV_SUCCESS;
+    mTmpRecord.mKey.setPdsId( *aPDSId );
+    mTmpRecord.mKey.setKey( *aKeyValue );
+
+    // note: operator[] inserts new element if key isn't found...
+    skv_server_record_lock_vault_t::iterator iter = mActiveLocks.find( mTmpRecord.mKey );
+
+    if( iter != mActiveLocks.end() )
+    {
+      skv_server_ccb_t *currentOwner = iter->second;
+      if( currentOwner != aOwner )
+      {
+        BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+          << "This record is already locked and we 0x" << (void*)aOwner
+          << " are NOT the owner 0x" << (void*)currentOwner
+          << EndLogLine;
+        status = SKV_ERRNO_RECORD_IS_LOCKED;
+      }
+      else
+      {
+        BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+          << "This record is already locked and we're the owner 0x" << (void*)aOwner
+          << EndLogLine;
+        *aRecLock = (skv_rec_lock_handle_t)&(iter->first);
+        status = SKV_SUCCESS;
+      }
+    }
+    else
+    {
+      BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+        << "This record didn't exist. Creating record lock for owner 0x" << (void*)aOwner
+        << EndLogLine;
+      std::pair<skv_server_record_lock_vault_t::iterator,bool> retval = mActiveLocks.insert( std::make_pair( mTmpRecord.mKey, (skv_server_ccb_t*)aOwner ) );
+      if( retval.second == true )
+      {
+        *aRecLock = (skv_rec_lock_handle_t)&(retval.first->first);
+        status = SKV_SUCCESS;
+      }
+      else
+        StrongAssertLogLine( 0 )
+          << "Lock creation failed while inserting key into map. Sorry, can't continue..."
+          << EndLogLine;
+    }
+
+    return status;
+  }
+
+  skv_status_t Unlock( const skv_rec_lock_handle_t aLock,
+                       const skv_server_ccb_t *aOwner )
+  {
+    skv_status_t status = SKV_SUCCESS;
+    skv_server_record_lock_key_t *lockPtr = (skv_server_record_lock_key_t*)aLock;
+    skv_server_record_lock_vault_t::iterator iter = mActiveLocks.find( *lockPtr );
+    if( iter != mActiveLocks.end() )
+      if( iter->second == aOwner )
+      {
+        BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+          << "This record is locked and we're the owner 0x" << (void*)aOwner
+          << ". Unlocking..."
+          << EndLogLine;
+        mActiveLocks.erase( *lockPtr );
+        status = SKV_SUCCESS;
+      }
+      else
+      {
+        BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+          << "This record is locked and we 0x" << (void*)aOwner
+          << " are NOT the owner 0x" << (void*)iter->second
+          << ". Nice try..."
+          << EndLogLine;
+        status = SKV_ERRNO_RECORD_IS_LOCKED;
+      }
+    else
+    {
+      BegLogLine( SKV_SERVER_RECORD_LOCK_MGR_LOG )
+        << "This record isn't locked. No-Op."
+        << EndLogLine;
+      status = SKV_SUCCESS;
+    }
+
+    return status;
+  }
+};
+
+
+
+#endif /* SKV_SERVER_SKV_SERVER_LOCK_MANAGER_HPP_ */

--- a/test/skv_base_test.cpp
+++ b/test/skv_base_test.cpp
@@ -338,6 +338,37 @@ int Test_Insert( int aDataSize, const char *aText )
                                                testFlag ),
                          SKV_SUCCESS,
                          mtext.c_str(), "UPDATE" );
+
+  testFlag = (skv_cmd_RIU_flags_t)(SKV_COMMAND_RIU_UPDATE | SKV_COMMAND_RIU_INSERT_USE_RECORD_LOCKS);
+  status += TEST_RESULT( skv_base_test_insert( "SKV_BASE_TEST_PDS",
+                                               Key,
+                                               aDataSize,
+                                               0,
+                                               testFlag),
+                         SKV_SUCCESS,
+                         mtext.c_str(), "UPD+LOCK" );
+
+  mtext = "ASYNC-INS:";
+  testFlag = (skv_cmd_RIU_flags_t)(SKV_COMMAND_RIU_UPDATE);
+  status += TEST_RESULT( skv_base_test_async_insert( "SKV_BASE_ITEST_PDS",
+                                                     Key,
+                                                     aDataSize,
+                                                     512,
+                                                     0,
+                                                     testFlag ),
+                         SKV_SUCCESS,
+                         mtext.c_str(), "UPDATE" );
+
+  testFlag = (skv_cmd_RIU_flags_t)(SKV_COMMAND_RIU_UPDATE | SKV_COMMAND_RIU_INSERT_USE_RECORD_LOCKS);
+  status += TEST_RESULT( skv_base_test_async_insert( "SKV_BASE_ITEST_PDS",
+                                                     Key,
+                                                     aDataSize,
+                                                     512,
+                                                     0,
+                                                     testFlag ),
+                         SKV_SUCCESS,
+                         mtext.c_str(), "UPD+LOCK" );
+
   return status;
 }
 


### PR DESCRIPTION
bug fix for server-side locking of records via insert-flag.  This function broke by separating LKVS and SKV state machine. Revised code now uses a lock manager that is separate from LKVS implementations and therefore (re-)enables lock functionality for all available LKVSs.
Extended skv_base_test to cover locking and some async insertion