### PR TITLE
remove obsoleted locking code

### DIFF
--- a/skv/server/skv_server_tree_based_container.hpp
+++ b/skv/server/skv_server_tree_based_container.hpp
@@ -139,13 +139,6 @@ public:
                               int aListOfKeysMaxCount,
                               skv_cursor_flags_t aFlags );
 
-  skv_status_t UnlockRecord( skv_rec_lock_handle_t aRecLock );
-
-  skv_status_t LockRecord( skv_pds_id_t aPDSId,
-                           char* aKeyData,
-                           int aKeySize,
-                           skv_rec_lock_handle_t* aRecLock );
-
   skv_status_t CreateCursor( char* aBuff,
                              int aBuffSize,
                              skv_server_cursor_hdl_t* aServCursorHdl );

--- a/skv/server/skv_server_tree_based_container_key.hpp
+++ b/skv/server/skv_server_tree_based_container_key.hpp
@@ -43,11 +43,9 @@ public:
    * OVERHEAD PER RECORD OVERHEAD PER RECORD
    ***************************************************/
 
-  skv_pds_id_t  mPDSId;
-  skv_key_t     mUserKey;
-  int            mValueSize;
-  char           mLockState;
-
+  skv_pds_id_t mPDSId;
+  skv_key_t mUserKey;
+  int mValueSize;
 
 
 #define SKV_MAGIC_VALUE  (-1)
@@ -77,24 +75,6 @@ public:
   GetKeySize()
   {
     return mUserKey.GetSize();
-  }
-
-  char *
-  GetLockStatePtr()
-  {
-    return &mLockState;
-  }
-
-  char
-  GetLockState()
-  {
-    return mLockState;
-  }
-
-  void
-  SetLockState( char aState )
-  {
-    mLockState = aState;
   }
 
   void

--- a/skv/server/skv_server_uber_pds.cpp
+++ b/skv/server/skv_server_uber_pds.cpp
@@ -89,13 +89,6 @@ Retrieve( skv_pds_id_t             aPDSId,
 
 skv_status_t
 skv_uber_pds_t::
-UnlockRecord( skv_rec_lock_handle_t   aRecLock )
-{
-  return mLocalData.UnlockRecord( aRecLock );
-}
-
-skv_status_t
-skv_uber_pds_t::
 CreateCursor( char*                    aBuff,
               int                      aBuffSize,
               skv_server_cursor_hdl_t* aServCursorHdl )
@@ -103,19 +96,6 @@ CreateCursor( char*                    aBuff,
   return mLocalData.CreateCursor( aBuff,
                                   aBuffSize,
                                   aServCursorHdl );
-}
-
-skv_status_t
-skv_uber_pds_t::
-LockRecord( skv_pds_id_t             aPDSId,
-            char*                    aKeyData,
-            int                      aKeySize,
-            skv_rec_lock_handle_t*   aRecLock )
-{
-  return mLocalData.LockRecord( aPDSId,
-                                aKeyData,
-                                aKeySize,
-                                aRecLock);
 }
 
 skv_status_t

--- a/skv/server/skv_server_uber_pds.hpp
+++ b/skv/server/skv_server_uber_pds.hpp
@@ -129,13 +129,6 @@ public:
                               int                 aListOfKeysMaxCount,
                               skv_cursor_flags_t aFlags );
 
-  skv_status_t UnlockRecord( skv_rec_lock_handle_t   aRecLock );
-
-  skv_status_t LockRecord( skv_pds_id_t             aPDSId,
-                           char*                     aKeyData,
-                           int                       aKeySize,
-                           skv_rec_lock_handle_t*   aRecLock );
-
   skv_status_t CreateCursor( char*                     aBuff,
                              int                       aBuffSize,
                              skv_server_cursor_hdl_t* aServCursorHdl );


### PR DESCRIPTION
no new function. Just code cleanup after previous introduction of lock mgr for LKVS.