### PR TITLE
enable some control over memory requirements via config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ foreach(_test ${TEST_SOURCES})
   add_executable(${TEST_NAME} ${_test})
   set_target_properties(${TEST_NAME} PROPERTIES COMPILE_DEFINITIONS
     "SKV_CLIENT_UNI;SKV_NON_MPI")
-  target_link_libraries(${TEST_NAME} skvc skv_client skv_common it_api fxlogger
+  target_link_libraries(${TEST_NAME} skvc skv_client it_api skv_common fxlogger
     ${SKV_COMMON_LINK_LIBRARIES})
   install(TARGETS ${TEST_NAME} DESTINATION bin)
 endforeach()
@@ -241,7 +241,7 @@ foreach(_test ${UNITTEST_SOURCES})
   add_executable(${TEST_NAME} ${_test})
   set_target_properties(${TEST_NAME} PROPERTIES COMPILE_DEFINITIONS
     "SKV_UNIT_TEST;SKV_CLIENT_UNI;SKV_NON_MPI")
-  target_link_libraries(${TEST_NAME} skvc skv_client skv_common it_api fxlogger
+  target_link_libraries(${TEST_NAME} skvc skv_client it_api skv_common fxlogger
     ${SKV_COMMON_LINK_LIBRARIES})
   install(TARGETS ${TEST_NAME} DESTINATION unittest)
 endforeach()
@@ -249,8 +249,8 @@ endforeach()
 foreach(_test ${TEST_MPI_SOURCES})
   get_filename_component(TEST_NAME ${_test} NAME_WE)
   add_executable(${TEST_NAME} ${_test})
-  target_link_libraries(${TEST_NAME} skvc_mpi skv_client_mpi skv_common
-    ${IT_API_LINK_LIBRARIES} fxlogger
+  target_link_libraries(${TEST_NAME} skvc_mpi skv_client_mpi
+    ${IT_API_LINK_LIBRARIES} skv_common fxlogger
     ${MPI_CXX_LIBRARIES} ${SKV_COMMON_LINK_LIBRARIES})
   install(TARGETS ${TEST_NAME} DESTINATION bin)
 endforeach()

--- a/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
+++ b/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
@@ -2559,7 +2559,7 @@ void RemoveFromAckQueue( struct connection *conn )
     << EndLogLine ;
 
   // first entry?
-  if( conn == conn_ptr )
+  if(( conn == conn_ptr ) && ( conn != FORWARDER_MAGIC_FLUSH_QUEUE_TERMINATOR ))
   {
     gDeferredAckList = conn->mNextDeferredAck;
     return;

--- a/it_api/it_api_o_sockets_cn_ion.hpp
+++ b/it_api/it_api_o_sockets_cn_ion.hpp
@@ -19,11 +19,9 @@
 #include <it_api_o_sockets_types.h>
 
 #define CNK_ROUTER_BUFFER_SIZE ( 32 * 1024 * 1024ull )
-#define CNK_ROUTER_PORT ( 10950 )
 
 enum {
   k_ApplicationBufferSize= CNK_ROUTER_BUFFER_SIZE ,
-  k_IONPort = CNK_ROUTER_PORT
 };
 
 struct connection *conn ;

--- a/it_api/it_api_o_sockets_cn_ion.hpp
+++ b/it_api/it_api_o_sockets_cn_ion.hpp
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <it_api_o_sockets_types.h>
 
-#define CNK_ROUTER_BUFFER_SIZE ( 32 * 1024 * 1024ull )
+#define CNK_ROUTER_BUFFER_SIZE ( 16 * 1024 * 1024ull )
 
 enum {
   k_ApplicationBufferSize= CNK_ROUTER_BUFFER_SIZE ,

--- a/it_api/it_api_o_sockets_routed.cpp
+++ b/it_api/it_api_o_sockets_routed.cpp
@@ -40,6 +40,7 @@
 //#include <netinet/tcp.h>
 
 #include <spi/include/kernel/rdma.h>
+#include <skv/common/skv_config.hpp>
 
 //#include <it_api_o_sockets_router.h>
 
@@ -533,12 +534,16 @@ public:
   pthread_t mRdmaResponderThread ;
   volatile bool mResponderKeepRunning;
   bool mEven ;
+  skv_configuration_t *mConfig;
 
   VerbsChannel() : mRdmaSocket( VERBS_CHANNEL_UNINITIALIZED ),
       mEven( false ),
       mRdmaSendBlocks( 0 ),
       mRdmaResponderThread( VERBS_CHANNEL_UNINITIALIZED ),
-      mResponderKeepRunning( false ) {}
+      mResponderKeepRunning( false )
+  {
+    mConfig = skv_configuration_t::GetSKVConfiguration();
+  }
 
   ~VerbsChannel() { Terminate(); }
   void Init(void) ;
@@ -570,11 +575,13 @@ void VerbsChannel::Init(void)
      mBuffer.Init() ;
      mEven = false ;
      mRdmaSendBlocks = 0 ;
+     mConfig = skv_configuration_t::GetSKVConfiguration();
+     uint32_t IONPort = mConfig->GetSKVForwarderPort();
      int rc_open = Kernel_RDMAOpen(&mRdmaSocket) ;
      BegLogLine(FXLOG_IONCN_BUFFER)
        << "Kernel_RDMAOpen rc=" << rc_open
        << EndLogLine ;
-     int rc_connect = Kernel_RDMAConnect(mRdmaSocket,k_IONPort) ;
+     int rc_connect = Kernel_RDMAConnect(mRdmaSocket,IONPort) ;
      BegLogLine(FXLOG_IONCN_BUFFER)
        << "Kernel_RDMAConnect rc=" << rc_connect
        << EndLogLine ;

--- a/skv/common/skv_config.cpp
+++ b/skv/common/skv_config.cpp
@@ -50,13 +50,14 @@ skv_configuration_t::skv_configuration_t( )
 
   mPersistentFilename      = DEFAULT_SKV_PERSISTENT_FILENAME;
   mPersistentFileLocalPath = DEFAULT_SKV_PERSISTENT_FILE_LOCAL_PATH;
+
+  mRdmaMemoryLimit = DEFAULT_SKV_RDMA_MEMORY_LIMIT;
 }
 
 // get the location and name of the config file
 int
 skv_configuration_t::GetConfigurationFile( const char *aConfigFile )
 {
-
   ifstream cFileStream;
   // check if user provided a file
   // safe string length check: if there are more than N letters in the file name, we're fine
@@ -194,6 +195,10 @@ skv_configuration_t::ReadConfigurationFile( const char *aConfigFile )
             mCommIF = cline.substr( valueIndex );
             break;
 
+          case SKV_CONFIG_SETTING_RDMA_MEMORY_LIMIT:
+            mRdmaMemoryLimit = std::strtoll( cline.substr( valueIndex ).c_str(), NULL, 10 ) * 1024 * 1024;
+            break;
+
           default:
             BegLogLine( 1 )
               << "skv_configuration_t::ReadConfigurationFile():: unknown parameter in"
@@ -231,7 +236,8 @@ skv_configuration_t::ReadConfigurationFile( const char *aConfigFile )
     << " ServerPort:" << mServerPort
     << " persFile: " << mPersistentFilename.c_str()
     << " persLocalFile: " << mPersistentFileLocalPath.c_str()
-    << " verbsDev" << mCommIF.c_str()
+    << " commIF: " << mCommIF.c_str()
+    << " RDMAmemLimit: " << mRdmaMemoryLimit
     << EndLogLine;
 
   return status;
@@ -261,6 +267,9 @@ skv_configuration_t::GetVariableCase( const string s, size_t *valueIndex )
 
     if( s.find( "COMM_IF") != string::npos )
       setting = SKV_CONFIG_SETTING_COMM_IF;
+
+    if( s.find( "RDMA_MEMORY") != string::npos )
+      setting = SKV_CONFIG_SETTING_RDMA_MEMORY_LIMIT;
   }
   // client variables
   else if( s.find( "SKV_CLIENT" ) != string::npos )
@@ -346,6 +355,12 @@ const char*
 skv_configuration_t::GetCommIF() const
 {
   return mCommIF.c_str();
+}
+
+const uint64_t
+skv_configuration_t::GetRdmaMemoryLimit() const
+{
+  return mRdmaMemoryLimit;
 }
 
 const string

--- a/skv/common/skv_config.cpp
+++ b/skv/common/skv_config.cpp
@@ -43,6 +43,7 @@ skv_configuration_t::skv_configuration_t( )
   mConfigFile = DEFAULT_CONFIG_FILE;
 
   mServerPort = DEFAULT_SKV_SERVER_PORT;
+  mForwarderPort = DEFAULT_SKV_FORWARDER_PORT;
 
   mMachineFile = DEFAULT_SKV_MACHINE_FILE;
 
@@ -175,6 +176,10 @@ skv_configuration_t::ReadConfigurationFile( const char *aConfigFile )
             SetSKVServerPort( (uint16_t)atoi( cline.substr( valueIndex ).c_str() ) );
             break;
 
+          case SKV_CONFIG_SETTING_FORWARDER_PORT:
+            mForwarderPort = (uint16_t)atoi( cline.substr( valueIndex ).c_str() );
+            break;
+
           case SKV_CONFIG_SETTING_READY_FILE:
             mReadyFile = cline.substr( valueIndex );
             break;
@@ -279,6 +284,9 @@ skv_configuration_t::GetVariableCase( const string s, size_t *valueIndex )
   // other/general variables
   else
   {
+    if( s.find( "FORWARDER_PORT" ) != string::npos )
+      setting = SKV_CONFIG_SETTING_FORWARDER_PORT;
+
     if( s.find( "PERSISTENT_FILENAME" ) != string::npos )
       setting = SKV_CONFIG_SETTING_PERSISTENT_FILENAME;
 
@@ -319,6 +327,12 @@ const uint32_t
 skv_configuration_t::GetSKVServerPort() const
 {
   return mServerPort;
+}
+
+const uint32_t
+skv_configuration_t::GetSKVForwarderPort() const
+{
+  return mForwarderPort;
 }
 
 void

--- a/skv/common/skv_config.hpp
+++ b/skv/common/skv_config.hpp
@@ -24,6 +24,7 @@ using namespace std;            // that's a bad place for using... ;-)...
 #endif
 
 #define DEFAULT_SKV_SERVER_PORT 17002
+#define DEFAULT_SKV_FORWARDER_PORT 10950
 #define DEFAULT_SKV_SERVER_READY_FILE "/tmp/skv_server.ready"
 #define DEFAULT_SKV_MACHINE_FILE "/etc/skv_machinefile"
 #define DEFAULT_SKV_PERSISTENT_FILENAME "skv_store"
@@ -34,6 +35,7 @@ using namespace std;            // that's a bad place for using... ;-)...
 typedef enum {
   SKV_CONFIG_SETTING_UNDEFINED,
   SKV_CONFIG_SETTING_SERVER_PORT,
+  SKV_CONFIG_SETTING_FORWARDER_PORT,
   SKV_CONFIG_SETTING_READY_FILE,
   SKV_CONFIG_SETTING_MACHINE_FILE,
   SKV_CONFIG_SETTING_PERSISTENT_FILENAME,
@@ -49,6 +51,7 @@ class skv_configuration_t
   static skv_configuration_t *mConfiguration;
 
   uint32_t  mServerPort;   // stored in host byte order
+  uint32_t  mForwarderPort;   // stored in host byte order
   string    mReadyFile;
   string    mMachineFile;
   string    mPersistentFilename;
@@ -74,6 +77,8 @@ public:
   const char* GetServerPersistentFileLocalPath() const;
 
   const uint32_t GetSKVServerPort() const;
+  const uint32_t GetSKVForwarderPort() const;
+
   // input in network byte order
   void SetSKVServerPort( uint32_t aServerPort );
 

--- a/skv/common/skv_config.hpp
+++ b/skv/common/skv_config.hpp
@@ -29,6 +29,7 @@ using namespace std;            // that's a bad place for using... ;-)...
 #define DEFAULT_SKV_PERSISTENT_FILENAME "skv_store"
 #define DEFAULT_SKV_PERSISTENT_FILE_LOCAL_PATH "/tmp/skv_store"
 #define DEFAULT_SKV_COMM_IF "roq0"
+#define DEFAULT_SKV_RDMA_MEMORY_LIMIT ( 2 * 1024 * 1024 * 1024 )
 
 typedef enum {
   SKV_CONFIG_SETTING_UNDEFINED,
@@ -38,6 +39,7 @@ typedef enum {
   SKV_CONFIG_SETTING_PERSISTENT_FILENAME,
   SKV_CONFIG_SETTING_PERSISTENT_FILE_LOCAL_PATH,
   SKV_CONFIG_SETTING_COMM_IF,
+  SKV_CONFIG_SETTING_RDMA_MEMORY_LIMIT
 } skv_config_setting_t;
 
 
@@ -52,6 +54,7 @@ class skv_configuration_t
   string    mPersistentFilename;
   string    mPersistentFileLocalPath;
   string    mCommIF;
+  uint64_t  mRdmaMemoryLimit;
 
   string    mConfigFile;
 
@@ -75,6 +78,8 @@ public:
   void SetSKVServerPort( uint32_t aServerPort );
 
   const char* GetCommIF() const;
+
+  const uint64_t GetRdmaMemoryLimit() const;
 
   const string GetConfigFileName() const;
 };

--- a/skv/server/skv_local_kv_event_queue.hpp
+++ b/skv/server/skv_local_kv_event_queue.hpp
@@ -35,7 +35,7 @@ public:
   }
   ~skv_local_kv_event_queue_t()
   {
-    delete mEventPool;
+    delete [] mEventPool;
   }
 
   skv_status_t Init() {

--- a/skv/server/skv_local_kv_request_queue.hpp
+++ b/skv/server/skv_local_kv_request_queue.hpp
@@ -35,12 +35,12 @@ class skv_local_kv_request_queue_t {
 public:
   skv_local_kv_request_queue_t( const size_t aSize = SKV_LOCAL_KV_MAX_REQUESTS ) : mFreeSlots( 0 ), mLenght( std::min( (size_t)aSize, (size_t)SKV_LOCAL_KV_MAX_REQUESTS ) )
   {
-    mRequestPool = NULL;
+    mRequestPool = new skv_local_kv_request_t[ mLenght ];
   }
   ~skv_local_kv_request_queue_t()
   {
     if( mRequestPool != NULL )
-      delete mRequestPool;
+      delete [] mRequestPool;
   }
 
   skv_status_t Init()

--- a/skv/server/skv_local_kv_rocksdb.hpp
+++ b/skv/server/skv_local_kv_rocksdb.hpp
@@ -79,7 +79,9 @@ public:
   skv_local_kv_rocksdb_worker_t( const uint32_t aQueueLengths )
     : mStalledCommand( NULL ),
       mRequestQueue( aQueueLengths ),
-      mDedicatedQueue( aQueueLengths )
+  // worst case: each worker gets a request that got initially processed by one worker
+  // note that constructor limits the length to max lenght
+      mDedicatedQueue( aQueueLengths * SKV_LOCAL_KV_WORKER_POOL_SIZE )
     {
     };
   ~skv_local_kv_rocksdb_worker_t() {};

--- a/skv/system/bgq/etc/skv_server.conf
+++ b/skv/system/bgq/etc/skv_server.conf
@@ -65,6 +65,13 @@ PERSISTENT_FILE_LOCAL_PATH = /tmp/skv_store
 SKV_SERVER_COMM_IF = roq0
 
 
+# RDMA Memory Limit allows to put a coarse limit on the amount of
+# registered/pinned memory [in MiB] to get allocated for RDMA data transfer
+# Note: this is per server process
+#
+# default: 2048
+SKV_SERVER_RDMA_MEMORY_LIMIT = 2048
+
 # future options:
 # RUN_LOCAL=yes/no
 # RUN_LOCAL_ADDRESS=10.0.0.1

--- a/skv/system/bgq/etc/skv_server.conf
+++ b/skv/system/bgq/etc/skv_server.conf
@@ -34,6 +34,13 @@
 #  listen on the 10 subsequent ports.  The actual port will be written to the machine file
 SKV_SERVER_PORT = 17002
 
+# specify which port the optional forwarder will listen on
+# this is only relevant for BG/Q CNK clients compiled for "sockets_routed" communication
+# default: 10950
+# 
+FORWARDER_PORT = 10950
+
+
 # the existence of the skv_server ready file signals that the server is running
 # you have to specify the name and location of that file
 # default: SKV_SERVER_READY_FILE = /tmp/skv_server.ready

--- a/test/skv_test_bulk.cpp
+++ b/test/skv_test_bulk.cpp
@@ -24,11 +24,9 @@ skv_client_t Client;
 #define DATA_SIZE        ( 4096 )
 
 #include "test_skv_utils.hpp"
-#include <skv/server/skv_server_heap_manager.hpp>   // to get the server space per snode!
 
 // #define NUMBER_OF_TRIES  (  16 * 512  )
 #define PURESTORAGE_FACTOR ( (double)0.7 )                                                      // factor to reflect space overhead in server space, represents the available fraction of space per server
-#define STORAGE_SPACE_PER_SNODE     ( (int)(PERSISTENT_IMAGE_MAX_LEN * PURESTORAGE_FACTOR) )    // space available per server (reduced by an arbitrary space-overhead factor
 #define MAX_NUMBER_OF_TRIES_PER_SRV (  250  )    // max number of attempts per server
 #define MAX_TEST_SIZE_EXP ( 15 )       // 2^x max value size
 #define SKV_TEST_START_INDEX ( 2 )    // 2^x min value size
@@ -114,6 +112,8 @@ main(int argc, char **argv)
 
   FxLogger_Init( argv[ 0 ] );
   pkTraceServer::Init();
+
+  skv_configuration_t *config = skv_configuration_t::GetSKVConfiguration();
 
   int Rank = 0;
   int NodeCount = 1;
@@ -277,7 +277,7 @@ main(int argc, char **argv)
     {
       int testDataSize = DataSizes[ sizeIndex ];
 
-      uint64_t total_records = (uint64_t)STORAGE_SPACE_PER_SNODE / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
+      uint64_t total_records = config->GetRdmaMemoryLimit() * (uint64_t)PURESTORAGE_FACTOR / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
       NUMBER_OF_TRIES = total_records / NodeCount;
 
       BegLogLine( 1 | SKV_TEST_LOG )

--- a/test/skv_test_insert_retrieve_async.cpp
+++ b/test/skv_test_insert_retrieve_async.cpp
@@ -24,11 +24,9 @@ skv_client_t Client;
 #define DATA_SIZE        ( 4096 )
 
 #include "test_skv_utils.hpp"
-#include <skv/server/skv_server_heap_manager.hpp>   // to get the server space per snode!
 
 // #define NUMBER_OF_TRIES  (  16 * 512  )
 #define PURESTORAGE_FACTOR ( (double)0.8 )                                                      // factor to reflect space overhead in server space, represents the available fraction of space per server
-#define STORAGE_SPACE_PER_SNODE     ( (int)(PERSISTENT_IMAGE_MAX_LEN * PURESTORAGE_FACTOR) )    // space available per server (reduced by an arbitrary space-overhead factor
 #define MAX_NUMBER_OF_TRIES_PER_SRV (  250  )    // max number of attempts per server
 #define MAX_TEST_SIZE_EXP ( 20 )       // 2^x max value size
 #define SKV_TEST_START_INDEX ( 2 )    // 2^x min value size
@@ -124,9 +122,10 @@ main(int argc, char **argv)
   FxLogger_Init( argv[ 0 ] );
   pkTraceServer::Init();
 
+  skv_configuration_t *config = skv_configuration_t::GetSKVConfiguration();
+
   int Rank = 0;
   int NodeCount = 1;
-
 
   /*****************************************************************************
    * Init MPI
@@ -276,7 +275,7 @@ main(int argc, char **argv)
     {
       int testDataSize = DataSizes[ sizeIndex ];
 
-      uint64_t total_records = (uint64_t)STORAGE_SPACE_PER_SNODE / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
+      uint64_t total_records = config->GetRdmaMemoryLimit() * (uint64_t)PURESTORAGE_FACTOR / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
       NUMBER_OF_TRIES = total_records / NodeCount;
 
       BegLogLine( 1 | SKV_TEST_LOG )

--- a/test/skv_test_insert_retrieve_sync.cpp
+++ b/test/skv_test_insert_retrieve_sync.cpp
@@ -41,7 +41,6 @@ static TraceClient SKVRetrieveFinis;
 
 // #define NUMBER_OF_TRIES  (  16 * 512  )
 #define PURESTORAGE_FACTOR ( (double)0.7 )                                                      // factor to reflect space overhead in server space, represents the available fraction of space per server
-#define STORAGE_SPACE_PER_SNODE     ( (int)(PERSISTENT_IMAGE_MAX_LEN * PURESTORAGE_FACTOR) )    // space available per server (reduced by an arbitrary space-overhead factor
 #define MAX_NUMBER_OF_TRIES_PER_SRV (  250  )    // max number of attempts per server
 #define MAX_TEST_SIZE_EXP ( 20 )       // 2^x max value size
 #define SKV_TEST_START_INDEX ( 2 )    // 2^x min value size
@@ -106,6 +105,8 @@ main(int argc, char **argv)
 
   FxLogger_Init( argv[ 0 ] );
   pkTraceServer::Init();
+
+  skv_configuration_t *config = skv_configuration_t::GetSKVConfiguration();
 
   int Rank = 0;
   int NodeCount = 1;
@@ -248,7 +249,8 @@ main(int argc, char **argv)
     {
       int testDataSize = DataSizes[ sizeIndex ];
 
-      uint64_t total_records = (uint64_t)STORAGE_SPACE_PER_SNODE / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
+      uint64_t total_records = config->GetRdmaMemoryLimit() * (uint64_t)PURESTORAGE_FACTOR / (uint64_t) testDataSize * (uint64_t)NUMBER_OF_SNODES;
+
       NUMBER_OF_TRIES = total_records / NodeCount;
 
       BegLogLine( 1 | SKV_TEST_LOG )


### PR DESCRIPTION
This introduces a new option for the config file to allow some control over registered/pinnned memory for RDMA transfers.
For the in-memory LKVS this sets the size of the available storage per server process. For the rocksdb LKVS is sets the size of the RDMA buffers.
So far it doesn't affect the memory consumption of the forwarder process. It would be nice to have especially for running at scale but it's a bit more work.