### PR TITLE
get rid of string allocator in retrieve

### DIFF
--- a/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
+++ b/it_api/cnk_router/it_api_cnk_multiplex_router.cpp
@@ -73,7 +73,7 @@ extern "C"
 #include <iwarpem_socket_access.hpp>
 #include <iwarpem_types.hpp>
 
-#define IT_API_MAX_ROUTER_SOCKETS ( 128 )
+#define IT_API_MAX_ROUTER_SOCKETS ( 256 )
 
 #if 1
 #include <rdma/rdma_cma.h>

--- a/skv/server/skv_local_kv_rocksdb.hpp
+++ b/skv/server/skv_local_kv_rocksdb.hpp
@@ -28,7 +28,7 @@
 // will be divided by the worker pool size and the max value size
 #define SKV_LOCAL_KV_MIN_OUTSTANDING_REQUESTS ( 16 )
 #define SKV_LOCAL_KV_MAX_VALUE_SIZE ( 1 * 1048576ul )
-#define SKV_LOCAL_KV_WORKER_POOL_SIZE ( 32 )
+#define SKV_LOCAL_KV_WORKER_POOL_SIZE ( 24 )
 
 #include <thread>
 #include <rocksdb/db.h>


### PR DESCRIPTION
also:
* adjusting resources for larger numbers of servers
* worker pool and rdma memory adjustments

